### PR TITLE
Example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The file named "Streaming analysis" includes the functions which can be used to 
 
     res   <- NULL
     data  <- rnorm(1000, mean=5, sd=2)
-    for(i in 1:nrow(data))
+    for(i in 1:NROW(data))
     {
         res <- mean_online(input=data[i], theta=res)
     }

--- a/README.md
+++ b/README.md
@@ -7,17 +7,12 @@ The files that include a statistic as file name are small working examples of th
 
 The file named "Streaming analysis" includes the functions which can be used to estimate the statistics online. The first argument of the functions is always the new data point (and in case of a statistic that requires more variables, then the first two arguments are the new input). The next argument is theta. Theta is a list of the current state of the sufficient statistics. We implemented the functions in such a way that if theta is missing, or when theta is an empty object (NULL), the function creates a list including the required sufficient statistics.  The output of the functions is theta, which is a list of updated sufficient statistics including the parameter of interest. So in a for-loop, one could use the functions as follows:
 
-res   <- NULL
-
-data  <-rnorm(1000,mean=5,sd=2)
-
-for(i in 1:nrow(data))
-
-{
-
-      res <-mean_online(input=data[i], theta=res)
-
-}
+    res   <- NULL
+    data  <- rnorm(1000, mean=5, sd=2)
+    for(i in 1:nrow(data))
+    {
+        res <- mean_online(input=data[i], theta=res)
+    }
 
 Below we list all the functions in Streaming analysis.R file including the required arguments,
 note that argument theta always has default values, such that you dont have to specify theta yourself.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Methodology
 In this repository we uploaded the R code belonging to the examples discussed in:  
 
-"Dealing with Data streams: an Online, Row-by-Row, Estimation Tutorial" (Methodology). 
+"Dealing with Data streams: an Online, Row-by-Row, Estimation Tutorial" (Methodology).
 
 The files that include a statistic as file name are small working examples of the statistic the file is named after. The code allows alterations of for example the sample sizes, means, standard deviations, number of variables, or number of groups depending on the statistic.
 
 The file named "Streaming analysis" includes the functions which can be used to estimate the statistics online. The first argument of the functions is always the new data point (and in case of a statistic that requires more variables, then the first two arguments are the new input). The next argument is theta. Theta is a list of the current state of the sufficient statistics. We implemented the functions in such a way that if theta is missing, or when theta is an empty object (NULL), the function creates a list including the required sufficient statistics.  The output of the functions is theta, which is a list of updated sufficient statistics including the parameter of interest. So in a for-loop, one could use the functions as follows:
 
-res   <- NULL 
+res   <- NULL
 
 data  <-rnorm(1000,mean=5,sd=2)
 
@@ -19,8 +19,8 @@ for(i in 1:nrow(data))
 
 }
 
-Below we list all the functions in Streaming analysis.R file including the required arguments, 
-note that argument theta always has default values, such that you dont have to specify theta yourself. 
+Below we list all the functions in Streaming analysis.R file including the required arguments,
+note that argument theta always has default values, such that you dont have to specify theta yourself.
 
 - mean_online(input, theta=list("n"=0,"Mean"=0))
 
@@ -42,5 +42,3 @@ note that argument theta always has default values, such that you dont have to s
 - etasq_online(input, input_group theta=list("group_id"=c(input_group),"n_groups"=1, "SS_w"=0.00001, "SS_t"=0.00001, "mean"=input,                                            "n"=0,"n_k"=c(0), "mean_k"=c(input)))
 
 - sgd_log(input_x, input_y, theta=list("n"=0, "beta"=rep(0,(1+length(input_x)))))
-
-


### PR DESCRIPTION
When trying the example code provided in the README file, I have found that `nrow` doesn't work with the vector returned by `rnorm(...)`. I'm using R 3.2.4.

There are a couple of ways to fix this:
- converting the vector to a matrix: e.g. `as.matrix(rnorm(...))`, and continue using `nrow`
- using another function to determine the number of rows of `data`: e.g. `length` or `NROW`.

I chose for the latter option because it most resembles the original example and is also usable when `data` gets to be a more complex object, i.e. a real matrix or data frame.